### PR TITLE
master works better with older repos than main

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -2,14 +2,14 @@ name: BDD Tests
 on:
   push:
     branches:
-      - main
+      - master
     paths-ignore:
     - 'README.md'
     - '.vscode/**'
     - '**.md'
   pull_request:
     branches:
-      - main
+      - master
     paths-ignore:
     - 'README.md'
     - '.vscode/**'

--- a/.github/workflows/tdd.yml
+++ b/.github/workflows/tdd.yml
@@ -2,13 +2,13 @@ name: TDD Tests
 on:
   push:
     branches:
-      - main
+      - master
     paths-ignore:
       - 'README.md'
       - '.vscode/**'
   pull_request:
     branches:
-      - main
+      - master
     paths-ignore:
     - 'README.md'
     - '.vscode/**'

--- a/features/steps/promotions_steps.py
+++ b/features/steps/promotions_steps.py
@@ -48,7 +48,7 @@ def step_impl(context):
             "amount": row["Amount"],
             "start_date": row["Start"],
             "end_date": row["End"],
-            "is_site_wide": row["Is_Site_Wide"] in ['True','true','1'],
+            "is_site_wide": row["Is_Site_Wide"] in ['True', 'true', '1'],
             "product_id": row["ProductID"]
         }
         context.resp = requests.post(rest_endpoint, json=payload)


### PR DESCRIPTION
Although recently the branch name changed from `master` to `main` in version control systems, "master" works better with the older repositories so it is better to stick with `master`. 